### PR TITLE
Add Ex command to open chat buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # NeoCopilot
 
-
 A Neovim plugin for using Github copilot with advanced integration
+
+## Ex Commands
+
+### `:NeoCopilotChat`
+
+This command opens two buffers, one for chat output and one for chat input, split to the side of the current buffer. The chat output buffer is opened on the left side, and the chat input buffer is opened on the right side. The buffers are split vertically, with the chat output buffer taking up 70% of the width and the chat input buffer taking up 30% of the width.

--- a/lua/neocopilot/init.lua
+++ b/lua/neocopilot/init.lua
@@ -8,4 +8,33 @@ function M.setup(user_config)
   -- Additional setup code can be added here
 end
 
+function M.open_chat_buffers()
+  -- Create a new vertical split
+  vim.cmd("vsplit")
+  
+  -- Open the chat output buffer on the left side
+  vim.cmd("leftabove vsplit")
+  vim.cmd("enew")
+  vim.bo.buftype = "nofile"
+  vim.bo.bufhidden = "hide"
+  vim.bo.swapfile = false
+  vim.bo.filetype = "chat_output"
+  vim.cmd("wincmd l")
+  
+  -- Open the chat input buffer on the right side
+  vim.cmd("enew")
+  vim.bo.buftype = "nofile"
+  vim.bo.bufhidden = "hide"
+  vim.bo.swapfile = false
+  vim.bo.filetype = "chat_input"
+  
+  -- Adjust the width of the splits
+  vim.cmd("wincmd h")
+  vim.cmd("vertical resize 70%")
+  vim.cmd("wincmd l")
+  vim.cmd("vertical resize 30%")
+end
+
+vim.api.nvim_create_user_command("NeoCopilotChat", M.open_chat_buffers, {})
+
 return M


### PR DESCRIPTION
Implement an Ex command to open chat buffers for input and output.

* **New Functionality**: Add a function `open_chat_buffers` in `lua/neocopilot/init.lua` to handle opening the chat output and input buffers.
* **Ex Command**: Add an Ex command `:NeoCopilotChat` to call the `open_chat_buffers` function.
* **Buffer Configuration**: Configure the chat output buffer to open on the left side and the chat input buffer to open on the right side, with a vertical split.
* **Buffer Properties**: Set buffer properties such as `buftype`, `bufhidden`, `swapfile`, and `filetype` for both buffers.
* **Split Adjustment**: Adjust the width of the splits, with the chat output buffer taking up 70% of the width and the chat input buffer taking up 30% of the width.
* **Documentation**: Update `README.md` to include documentation for the new Ex command `:NeoCopilotChat`.

