### PR TITLE
Add Copilot integration for chat input buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ A Neovim plugin for using Github copilot with advanced integration
 ### `:NeoCopilotChat`
 
 This command opens two buffers, one for chat output and one for chat input, split to the side of the current buffer. The chat output buffer is opened on the left side, and the chat input buffer is opened on the right side. The buffers are split vertically, with the chat output buffer taking up 70% of the width and the chat input buffer taking up 30% of the width.
+
+### Pressing Ctrl + s in the input chat buffer
+
+When you write in the input chat buffer and press Ctrl + s, the prompt is sent to Github Copilot, and the response is presented in the top output buffer.

--- a/lua/neocopilot/init.lua
+++ b/lua/neocopilot/init.lua
@@ -33,6 +33,23 @@ function M.open_chat_buffers()
   vim.cmd("vertical resize 70%")
   vim.cmd("wincmd l")
   vim.cmd("vertical resize 30%")
+  
+  -- Set key mapping for Ctrl + s in the input chat buffer
+  vim.api.nvim_buf_set_keymap(0, "i", "<C-s>", "<cmd>lua require('neocopilot').send_prompt_to_copilot()<CR>", { noremap = true, silent = true })
+end
+
+function M.send_prompt_to_copilot()
+  local input_bufnr = vim.fn.bufnr('%')
+  local input_text = vim.api.nvim_buf_get_lines(input_bufnr, 0, -1, false)
+  local prompt = table.concat(input_text, "\n")
+  
+  local response = utils.get_copilot_response(prompt)
+  
+  -- Get the output buffer number
+  local output_bufnr = vim.fn.bufnr('chat_output')
+  
+  -- Set the response in the output buffer
+  vim.api.nvim_buf_set_lines(output_bufnr, 0, -1, false, vim.split(response, "\n"))
 end
 
 vim.api.nvim_create_user_command("NeoCopilotChat", M.open_chat_buffers, {})

--- a/lua/neocopilot/utils.lua
+++ b/lua/neocopilot/utils.lua
@@ -5,4 +5,23 @@ function M.is_copilot_available()
   return copilot_status
 end
 
+function M.get_copilot_response(prompt)
+  local copilot = require("copilot")
+  local copilot_api = require("copilot.api")
+
+  local request_body = {
+    prompt = prompt,
+    max_tokens = 100,
+    temperature = 0.7,
+  }
+
+  local response = copilot_api.complete(request_body)
+
+  if response and response.choices and response.choices[1] then
+    return response.choices[1].text
+  else
+    return "Error: Unable to get response from Github Copilot"
+  end
+end
+
 return M


### PR DESCRIPTION
Add functionality to send prompt to Github Copilot and present response in the top output buffer when pressing Ctrl + s in the input chat buffer.

* **`lua/neocopilot/init.lua`**:
  - Add `send_prompt_to_copilot` function to handle sending the prompt to Github Copilot and presenting the response in the top output buffer.
  - Add key mapping for Ctrl + s in the input chat buffer to call `send_prompt_to_copilot`.

* **`lua/neocopilot/utils.lua`**:
  - Add `get_copilot_response` function to send the prompt to Github Copilot and return the response using their APIs.

* **`README.md`**:
  - Update documentation to include the new functionality for pressing Ctrl + s in the input chat buffer.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Tebro/neocopilot/pull/3?shareId=f61200ad-8fba-4689-899b-8822a450399f).