### PR TITLE
Add installation instructions using the lazy plugin manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ This command opens two buffers, one for chat output and one for chat input, spli
 ### Pressing Ctrl + s in the input chat buffer
 
 When you write in the input chat buffer and press Ctrl + s, the prompt is sent to Github Copilot, and the response is presented in the top output buffer.
+
+## Installation
+
+To install NeoCopilot using the lazy plugin manager, add the following to your plugin configuration:
+
+```lua
+{
+  "Tebro/neocopilot",
+  config = function()
+    require("neocopilot").setup()
+  end,
+}
+```

--- a/lua/neocopilot/config.lua
+++ b/lua/neocopilot/config.lua
@@ -9,4 +9,16 @@ function M.update(user_config)
   M.config = vim.tbl_deep_extend("force", {}, M.default_config, user_config or {})
 end
 
+function M.install_lazy_plugin_manager()
+  print("To install NeoCopilot using the lazy plugin manager, add the following to your plugin configuration:")
+  print([[
+  {
+    "Tebro/neocopilot",
+    config = function()
+      require("neocopilot").setup()
+    end,
+  }
+  ]])
+end
+
 return M

--- a/lua/neocopilot/init.lua
+++ b/lua/neocopilot/init.lua
@@ -5,6 +5,7 @@ local utils = require("neocopilot.utils")
 
 function M.setup(user_config)
   config.update(user_config)
+  config.install_lazy_plugin_manager()
   -- Additional setup code can be added here
 end
 


### PR DESCRIPTION
Add installation instructions for the lazy plugin manager.

* **README.md**
  - Add a new section for installation instructions using the lazy plugin manager.
  - Include a code block with the installation instructions.

* **lua/neocopilot/config.lua**
  - Add a new function `install_lazy_plugin_manager` to include installation instructions.

* **lua/neocopilot/init.lua**
  - Call the new `install_lazy_plugin_manager` function from `config.lua` in the `setup` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Tebro/neocopilot/pull/4?shareId=61a68617-69df-4ff6-b9de-ce1ed933ab8b).