### PR TITLE
Fix plugin issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Neovim plugin for using Github copilot with advanced integration
 
 ### `:NeoCopilotChat`
 
-This command opens two buffers, one for chat output and one for chat input, split to the side of the current buffer. The chat output buffer is opened on the left side, and the chat input buffer is opened on the right side. The buffers are split vertically, with the chat output buffer taking up 70% of the width and the chat input buffer taking up 30% of the width.
+This command opens two buffers, one for chat output and one for chat input, split below the current buffer. The chat output buffer is opened on the top, and the chat input buffer is opened on the bottom. The buffers are split horizontally, with the chat output buffer taking up 70% of the height and the chat input buffer taking up 30% of the height.
 
 ### Pressing Ctrl + s in the input chat buffer
 

--- a/lua/neocopilot/config.lua
+++ b/lua/neocopilot/config.lua
@@ -9,16 +9,4 @@ function M.update(user_config)
   M.config = vim.tbl_deep_extend("force", {}, M.default_config, user_config or {})
 end
 
-function M.install_lazy_plugin_manager()
-  print("To install NeoCopilot using the lazy plugin manager, add the following to your plugin configuration:")
-  print([[
-  {
-    "Tebro/neocopilot",
-    config = function()
-      require("neocopilot").setup()
-    end,
-  }
-  ]])
-end
-
 return M

--- a/lua/neocopilot/init.lua
+++ b/lua/neocopilot/init.lua
@@ -5,35 +5,33 @@ local utils = require("neocopilot.utils")
 
 function M.setup(user_config)
   config.update(user_config)
-  config.install_lazy_plugin_manager()
   -- Additional setup code can be added here
 end
 
 function M.open_chat_buffers()
-  -- Create a new vertical split
-  vim.cmd("vsplit")
+  -- Create a new horizontal split
+  vim.cmd("split")
   
-  -- Open the chat output buffer on the left side
-  vim.cmd("leftabove vsplit")
+  -- Open the chat output buffer on the top
   vim.cmd("enew")
   vim.bo.buftype = "nofile"
   vim.bo.bufhidden = "hide"
   vim.bo.swapfile = false
   vim.bo.filetype = "chat_output"
-  vim.cmd("wincmd l")
+  vim.cmd("wincmd j")
   
-  -- Open the chat input buffer on the right side
+  -- Open the chat input buffer on the bottom
   vim.cmd("enew")
   vim.bo.buftype = "nofile"
   vim.bo.bufhidden = "hide"
   vim.bo.swapfile = false
   vim.bo.filetype = "chat_input"
   
-  -- Adjust the width of the splits
-  vim.cmd("wincmd h")
-  vim.cmd("vertical resize 70%")
-  vim.cmd("wincmd l")
-  vim.cmd("vertical resize 30%")
+  -- Adjust the height of the splits
+  vim.cmd("wincmd k")
+  vim.cmd("resize 70%")
+  vim.cmd("wincmd j")
+  vim.cmd("resize 30%")
   
   -- Set key mapping for Ctrl + s in the input chat buffer
   vim.api.nvim_buf_set_keymap(0, "i", "<C-s>", "<cmd>lua require('neocopilot').send_prompt_to_copilot()<CR>", { noremap = true, silent = true })


### PR DESCRIPTION
Remove the installation instructions from being printed on each start of Neovim and adjust the buffer layout.

* **Remove installation instructions print:**
  - Remove the `install_lazy_plugin_manager` function from `lua/neocopilot/config.lua`.
  - Remove the call to `install_lazy_plugin_manager` in the `setup` function in `lua/neocopilot/init.lua`.

* **Adjust buffer layout:**
  - Modify the `open_chat_buffers` function in `lua/neocopilot/init.lua` to use horizontal splits instead of vertical splits.
  - Update the description of the `:NeoCopilotChat` command in `README.md` to reflect the new horizontal split layout.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Tebro/neocopilot/pull/5?shareId=b5b3cd77-9028-47bc-bcf7-3b71294597a3).